### PR TITLE
Create counting guidelines

### DIFF
--- a/source/versions/4/counting-guidelines.md
+++ b/source/versions/4/counting-guidelines.md
@@ -1,6 +1,6 @@
 # `#counting` Guidelines
 
-This is a description of how to count with friends (specifically in the #counting channel). Please adhere to these guidelines in order to preserve the integrity of the never-ending quest!
+This is a description of how to count with friends (specifically in the #counting channel). Please adhere to these guidelines in order to keep the channel orderly!
 
 ## Guidelines
 

--- a/source/versions/4/counting-guidelines.md
+++ b/source/versions/4/counting-guidelines.md
@@ -1,0 +1,16 @@
+# `#counting` Guidelines
+
+This is a description of how to count with friends (specifically in the #counting channel). Please adhere to these guidelines in order to preserve the integrity of the never-ending quest!
+
+## Guidelines
+
+1. Only send the number that is 1 above the previous number sent (e.g. "8123" -> "8124")
+2. Only send a message when the last messenger is not you-- you can count up from others' numbers, but not your own.
+3. You may only include alphabetical messages through edits. Common practice is to use parentheses after your number when doing this.
+    a. If the last two digits of your message are "69", after sending, you are strongly advised to edit your message to include "(nice)" after.
+
+## Useful Things to Know
+
+Adam has made a bot that enforces most of the guidelines above. However, it gets out of tune sometimes, and needs to be reset; if it's deleting your messages, send `<c reset` to the #bot-poking channel. Adam's bot should acknowledge the command and stop doing that.
+
+Sometimes, when in a "rally" (quickly counting up when two or more people are active in `#counting` at the same time), Discord will lag out. This may be because of the speed that messages are being sent. We're not sure. You can fix it quickly by pressing `CTRL+R` on your keyboard, or restarting the app on mobile.


### PR DESCRIPTION
This adds in guidelines on how to send messages in the counting channel. 

Currently, the counting channel is governed both by unspoken rules, and by Adam's bot, which is created by those rules, but also added some rules by its existence. I think at some point the rules were formalized, but I can't find them in the pins or wherever.

 It may be in the interest of active people to have a defined ruleset that:

* Can be shown to people to get them into counting
* Is a way to let already-active people know of unspoken rules they may not know of