### PR TITLE
Fixed syntax error in CSS media query

### DIFF
--- a/source/versions/4/asset/style.css
+++ b/source/versions/4/asset/style.css
@@ -338,7 +338,6 @@
         margin: auto;
     }
 
-    #
 
     @media only screen and (min-width: 600px) {
         .syntax-checker-widget .drag-handle {


### PR DESCRIPTION
This PR fixes a syntax error that causes all devices to be displayed as mobile