### PR TITLE
Minor improvements to short URL generation; breadcrumb style

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "",
   "dependencies": {
     "compression": "^1.7.4",
-    "erb": "^1.3.0-hf.1",
     "express": "^4.17.1",
     "marked-it-core": "^0.14.1",
     "parse5": "^6.0.0",

--- a/source/_redirects
+++ b/source/_redirects
@@ -2,3 +2,10 @@
 
 /versions/latest  /versions/4
 /versions/latest/*  /versions/4/:splat
+
+# redirect vanity domains to cannonical (doc.nhs.gg)
+
+http://docs.nhs.gg/* https://doc.nhs.gg/:splat 301!
+https://docs.nhs.gg/* https://doc.nhs.gg/:splat 301!
+http://d.nhs.gg/* https://doc.nhs.gg/:splat 301!
+https://d.nhs.gg/* https://doc.nhs.gg/:splat 301!

--- a/source/versions/4/asset/share-button.js
+++ b/source/versions/4/asset/share-button.js
@@ -4,7 +4,7 @@ window.addEventListener("load", function() {
 
     let shareButton = document.getElementById("share-button"),
         shareUrlPath = shareButton.getAttribute("data-shorten-address"),
-        shortShareUrl = new URL("/" + shareUrlPath, location.origin);
+        shortShareUrl = new URL("/" + shareUrlPath, location.origin.match(/https:\/\/d(ocs?)?.nhs.gg/) ? "https://d.nhs.gg" : location.origin); //go to shortener domain if applicable
     let sharePop;
 
     if(shareButton) {

--- a/source/versions/4/asset/style.css
+++ b/source/versions/4/asset/style.css
@@ -455,21 +455,21 @@
     }
 
     .breadcrumb li a {
-        color: inherit;
+        color: #0095dd;
         text-decoration: none;
     }
 
     .breadcrumb li::before {
         content: "\0000A0/";
-        font-weight: normal;
+        font-weight: lighter;
     }
 
     .breadcrumb li:first-child::before {
         content: "";
     }
 
-    .breadcrumb li:last-child {
-        font-weight: bold;
+    .breadcrumb li:last-child a {
+        color: inherit;
     }
 
     svg.icon {


### PR DESCRIPTION
Use https://d.nhs.gg to make URLs shorter. 
Add redirects for both https://doc.nhs.gg and https://d.nhs.gg to make people use the canonical domain.

Minor styling cleanup for breadcrumbs-- recolor and adjust font weight to make sure they're interpreted as links